### PR TITLE
Fix/converters windows compability

### DIFF
--- a/sbin/book_from_stendhal.py
+++ b/sbin/book_from_stendhal.py
@@ -24,7 +24,7 @@ import json
 def print_json_book_from_stendhal(fpath, item_origin):
     title = None
     author = None
-    with open(fpath, "r") as file:
+    with open(fpath, "r", encoding="utf-8") as file:
         while True:
             line = file.readline().strip()
             if line == "pages:":
@@ -46,6 +46,9 @@ def print_json_book_from_stendhal(fpath, item_origin):
 
 
 if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 book_from_stendhal.py \"path/to/my_book.stendhal\" \"Server name\"")
+        exit()
     fpath = sys.argv[1]
     item_origin = ' '.join(sys.argv[2:]) if len(sys.argv) > 2 else None
     print_json_book_from_stendhal(fpath, item_origin)

--- a/sbin/book_html_from_json.py
+++ b/sbin/book_html_from_json.py
@@ -58,7 +58,10 @@ def write_books_htmls_from_json_paths(source_paths):
         print(f'Could not read {index_json_path}: {e}', file=sys.stderr)
 
     for path in source_paths:
-        with open(path, 'r') as f:
+        f = sys.stdin
+        if path != '/dev/stdin':
+            f = open(path, 'r')
+        with f:
             write_books_htmls_from_json(f, index)
 
     with open(index_json_path, 'w') as f:
@@ -156,7 +159,7 @@ def write_books_htmls_from_json(source_file, books_metadata=None):
             os.makedirs(dir_path, exist_ok=True)
             if write:
                 book_html = template_book(book_json)
-                with open(page_path, 'w') as file_html:
+                with open(page_path, 'w', encoding='utf-8') as file_html:
                     file_html.write(book_html)
             if books_metadata is not None:
                 books_metadata[index_key] = book_json_metadata


### PR DESCRIPTION
Got error on windows on first attempt of converting stendhal file to JSON file via `book_from_stendhal.py`. 
![image](https://github.com/user-attachments/assets/c4baac9e-b6f9-4589-a5db-3d379580a2c1)
When debug printing the file, the file was open as cp1252 encoding. Issue not present with forcing utf-8 encoding.
`<_io.TextIOWrapper name='.\\sbin\\color.stendhal' mode='rt' encoding='cp1252'>`


`book_html_from_json.py` assumes unix system; `/dev/stdin` is used as name for stdin virtual file. Windows lacks such a virtual fil. Running the file with stdin input results in a file not found exception. Fix: If path provided is `/dev/stdin`, use python sys.stdin as a file, instead of opening some path.
Similar encoding error as stendhal->json happens when writing html file. Same utf-8 encoding enforcing fixed issue.


Tested both files after changes on Windows and Ubuntu (WSL). No issues observed.